### PR TITLE
Remove of the Applet dependency in Game.

### DIFF
--- a/src/main/java/battleship/Game.java
+++ b/src/main/java/battleship/Game.java
@@ -6,7 +6,6 @@
 
 package battleship;
 
-import java.applet.Applet;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.io.BufferedReader;
@@ -28,7 +27,7 @@ import javax.swing.JOptionPane;
  *
  * @author 0777974
  */
-public abstract class Game extends Applet implements ActionListener {
+public abstract class Game implements ActionListener {
 
   protected boolean settingUp = false;
   protected boolean yourTurn = false;


### PR DESCRIPTION
java.applet.Applet is deprecated for a couple of years by now. The application function well without the depedency. Time to get rid of it with this commit.