### PR TITLE
Introduce cancel-in-progress in the pull requests build.

### DIFF
--- a/.github/workflows/build-pull-request.yml
+++ b/.github/workflows/build-pull-request.yml
@@ -1,7 +1,13 @@
-name: SonarCloud
+name: Build Pull request
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+
+# This allows a subsequently queued workflow run to interrupt previous runs
+concurrency:
+  group: "${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}"
+  cancel-in-progress: true
+
 jobs:
   build:
     name: Build and analyze

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          fetch-depth: 0 # Shallow  clones should be disabled for a better relevancy of analysis
+          fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
       - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -1,5 +1,5 @@
 ---
-name: build-release
+name: Build release
 on:
   push:
     branches:

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
+          fetch-depth: 0 # Shallow  clones should be disabled for a better relevancy of analysis
       - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:


### PR DESCRIPTION
Previously it could happen that GitHub action was working on a Pull Request while another update comes in for the same Pull Request. The previously run should stop at is has no more value.